### PR TITLE
this.sys.game.canvas is 0 in preload() and create()

### DIFF
--- a/apps/example-app/src/app/home/home.page.ts
+++ b/apps/example-app/src/app/home/home.page.ts
@@ -9,10 +9,19 @@ import { PhaserSingletonService } from 'libs/example-app/phaser/singleton/src/li
     styleUrls: ['home.page.scss'],
 })
 export class HomePageComponent implements OnInit {
-    /**
+      /**
      * * On Init, initilize the Phaser Singleton instance
+     * The initialisation is delayed by 500ms to give the HomePage the chance to render 
+     * the <div class="phaser" id="forge-main">
+     * 
+     * If we don't delay it, the canvas size in preload() and create() will be 0. 
+     * With the delay the canvas size will be set correctly.
      */
     async ngOnInit() {
+        setTimeout(this.init, 500);
+    }
+
+    async init() {
         await PhaserSingletonService.init();
     }
 }


### PR DESCRIPTION
By the delaying the init a bit, the home component has a moment to render the div/canvas. So the width and height will be set correctly in the Game Object in the Phaser Singleton

# Pull request type

-   [ x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation content changes
-   [ ] E2E Test(s)
-   [ ] Other (please describe):

# What is the current behavior?
Canvas height and width is 0 in preload() and create()

# What is the new behavior?
The canvas height and width is set correctly in preload() and create()

# Does this introduce a breaking change?

-   [ ] Yes
-   [ x] No

# Other information
This is not the most prettiest of solutions, but fixes the issue. As well could start the discussion for a more elegant solution.